### PR TITLE
README: added macOS requirenment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ With AnyCable you can use channels, client-side JS, broadcasting - (_almost_) al
 - PostgreSQL >= 9.4
 - Redis
 - [hivemind](https://github.com/DarthSim/hivemind) (optional)
+- macOS (optional, [compile anycable-go yourself](https://github.com/anycable/anycable-go#installation) in case you run the demo in other OS)
 
 
 ## Usage


### PR DESCRIPTION
Since anycable-go provided with the demo was compiled for macOS, it would be helpful to at least inform users about this.
