### PR TITLE
Remove Product#serialized which overrides ApplicationRecord#serialized

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,10 +7,6 @@ class Product < ApplicationRecord
 
   belongs_to :basket, counter_cache: :items_count
 
-  def serialized(*)
-    { name: name, category: category, icon_path: icon_path }
-  end
-
   private
 
   def set_defaults


### PR DESCRIPTION
The override doesn't include the `id` attribute that is [declared in the serializer][1], so it ends up breaking the frontend's `addProduct` function [which begins with][2]:
```
return if $("#product_#{data.id}")[0]
```
because `data.id` is `undefined`.

As a result, if you try to add a product two elements will get added to the DOM, e.g. `#product_` and `#product_7`, instead of just the one `#product_7`.

[1]: https://github.com/anycable/anycable_demo/blob/c0ec5cff5a1774fde3081f4bb5fd564a164fc237/app/serializers/product_serializer.rb#L2
[2]: https://github.com/anycable/anycable_demo/blob/c0ec5cff5a1774fde3081f4bb5fd564a164fc237/app/assets/javascripts/products.coffee#L15