### PR TITLE
Add chromedriver-helper dependency to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem 'json_spec'
   gem 'show_me_the_cookies'
 
+  gem 'chromedriver-helper'
   gem 'selenium-webdriver', require: false
 
   gem 'rack_session_access'


### PR DESCRIPTION
This gem was declared in the `Gemfile.lock`:
https://github.com/anycable/anycable_demo/blob/c0ec5cff5a1774fde3081f4bb5fd564a164fc237/Gemfile.lock#L85

but not in the `Gemfile`, so reinstalling dependencies from the `Gemfile` was producing a `Gemfile.lock` without `chromedriver-helper`.