### PR TITLE
[Example] Redis Sentinel

### DIFF
--- a/.dockerdev/redis-sentinel/entrypoint.sh
+++ b/.dockerdev/redis-sentinel/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cp /redis/sentinel.conf.template /etc/sentinel.conf
+
+sed -i "s/\$SENTINEL_MASTER/$SENTINEL_MASTER/g" /etc/sentinel.conf
+sed -i "s/\$SENTINEL_QUORUM/$SENTINEL_QUORUM/g" /etc/sentinel.conf
+sed -i "s/\$SENTINEL_DOWN_AFTER/$SENTINEL_DOWN_AFTER/g" /etc/sentinel.conf
+sed -i "s/\$SENTINEL_FAILOVER/$SENTINEL_FAILOVER/g" /etc/sentinel.conf
+
+redis-server /etc/sentinel.conf --sentinel

--- a/.dockerdev/redis-sentinel/sentinel.conf.template
+++ b/.dockerdev/redis-sentinel/sentinel.conf.template
@@ -1,0 +1,8 @@
+port 26379
+
+dir /tmp
+
+sentinel monitor $SENTINEL_MASTER redis 6379 $SENTINEL_QUORUM
+sentinel down-after-milliseconds $SENTINEL_MASTER $SENTINEL_DOWN_AFTER
+sentinel parallel-syncs $SENTINEL_MASTER 1
+sentinel failover-timeout $SENTINEL_MASTER $SENTINEL_FAILOVER

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ if ENV["LOCAL_CABLE"]
   gem 'anycable', path: '../anycable'
   gem 'anycable-rails', path: '../anycable-rails'
 else
+  gem 'anycable', github: 'anycable/anycable', branch: '1.0-dev'
   gem 'anycable-rails', '1.0.0.preview2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/anycable/anycable.git
+  revision: 99ad5b7a3aa0d4d078a4ff0fab6b96b01aee6cfa
+  branch: 1.0-dev
+  specs:
+    anycable (1.0.0.preview2)
+      anyway_config (>= 1.4.2)
+      grpc (~> 1.17)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -63,9 +72,6 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    anycable (1.0.0.preview2)
-      anyway_config (>= 1.4.2)
-      grpc (~> 1.17)
     anycable-rails (1.0.0.preview2)
       anycable (~> 1.0.0.preview2)
       rails (>= 5)
@@ -347,6 +353,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  anycable!
   anycable-rails (= 1.0.0.preview2)
   autoprefixer-rails
   better_errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-app-service-template: &app
     RAILS_ENV: ${RAILS_ENV:-development}
     ANYCABLE_DEBUG: ${DEBUG:-0}
     ANYCABLE_RPC_HOST: 0.0.0.0:50051
+    ANYCABLE_REDIS_SENTINELS: redis-sentinel:26379
 
 x-backend: &backend
   <<: *app
@@ -64,19 +65,50 @@ services:
       timeout: 3s
       retries: 30
 
+  redis-slave:
+    image: redis:5.0-alpine
+    command: redis-server --slaveof redis 6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - redis:/data
+
+  redis-sentinel: &redis-sentinel
+    image: redis:5.0-alpine
+    volumes:
+      - ./.dockerdev/redis-sentinel:/redis
+    working_dir: /redis
+    entrypoint: ./entrypoint.sh
+    environment:
+      SENTINEL_QUORUM: 2
+      SENTINEL_DOWN_AFTER: 1000
+      SENTINEL_FAILOVER: 1000
+      SENTINEL_MASTER: redis
+    ports:
+      - 26379
+    depends_on:
+      redis:
+        condition: service_started
+      redis-slave:
+        condition: service_started
+
   anycable:
     image: 'anycable/anycable-go:1.0.0.preview1'
     ports:
       - "8080:8080"
+    volumes:
+      - ./bin/:/usr/local/bin
     environment:
       PORT: 8080
       ANYCABLE_HOST: 0.0.0.0
       REDIS_URL: redis://redis:6379/0
       ANYCABLE_RPC_HOST: rpc:50051
       ANYCABLE_DEBUG: ${DEBUG:-0}
+      ANYCABLE_REDIS_SENTINELS: redis-sentinel:26379
+      ANYCABLE_REDIS_SENTINEL_DISCOVERY_INTERVAL: 2
     depends_on:
       - redis
-      - rpc
 
 volumes:
   redis:


### PR DESCRIPTION
## How to use this branch

- Build anycable-go [with Sentinel support](https://github.com/anycable/anycable-go/pull/95) for Linux (`make build-linux`) and put in into `bin/` folder of this project.

- Provision Docker dev env if not yet:

```sh
dip provision
```

- Start Redis, slave and first sentinel:

```
dip up redis-sentinel
```

- Add more sentinels for quorum:

```sh
docker-compose scale redis-sentinel=3
```

- Run WebSocket server with debug output:

```sh
DEBUG=1 dip up anycable
```

- Run Rails console:

```sh
dip rails c
```

- In Rails console, broadcast messages to see whether `anycable-go` sees them:

```ruby
num = 0
# repeat as many times as you want, all the messages will have different bodies
ActionCable.server.broadcast "all", "test_#{(num = num.succ}"
```

- While broadcasting messages, do the following:

```sh
# pause master Redis
docker pause anycable_demo_redis_1

# unpause master Redis
docker unpause anycable_demo_redis_1

# pause slave
docker pause anycable_demo_redis-slave_1
```

Between pausing/unpausing Redis instances, try to broadcast messages and see if the _channel_ is alive.